### PR TITLE
Fixed OSX Podspec issue

### DIFF
--- a/TPCircularBuffer.podspec
+++ b/TPCircularBuffer.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files       = '*.{c,h}'
   s.requires_arc       = false
   s.frameworks         = 'AudioToolbox'
-  s.platform           = :ios, '4.3', :osx, '10.0'
+  s.platform           = { :ios, '4.3', :osx, '10.0' }
 end


### PR DESCRIPTION
This is a quick fix to the podspec to make sure the OSX field gets included in the platform declaration. Just updated [EZAudio](https://github.com/syedhali/EZAudio) to use this in the master repo, but this is still an issue for people using Cocoapods.

### Current error (TPCircularBuffer 1.3 on OSX):
```
Encountered an unknown error (The platform of the target `Pods` (OS X 10.8) is not compatible with `TPCircularBuffer (1.3)`
```

Cheers!