### PR TITLE
fix podspec syntax

### DIFF
--- a/TPCircularBuffer.podspec
+++ b/TPCircularBuffer.podspec
@@ -15,5 +15,6 @@ Pod::Spec.new do |s|
   s.source_files       = '*.{c,h}'
   s.requires_arc       = false
   s.frameworks         = 'AudioToolbox'
-  s.platform           = { :ios, '4.3', :osx, '10.0' }
+  s.ios.deployment_target = '4.3'
+  s.osx.deployment_target = '10.8'
 end


### PR DESCRIPTION
> When supporting multiple platforms you should use deployment_target below instead.

https://guides.cocoapods.org/syntax/podspec.html#platform