### PR TITLE
Silence aggressive int/uint compiler warnings and align API with Core Audio

### DIFF
--- a/TPCircularBuffer+AudioBufferList.c
+++ b/TPCircularBuffer+AudioBufferList.c
@@ -224,7 +224,7 @@ void TPCircularBufferDequeueBufferListFrames(TPCircularBuffer *buffer, UInt32 *i
         if ( !bufferList ) break;
         
         hasTimestamp = true;
-        unsigned long bytesToCopy = min(bytesToGo, bufferList->mBuffers[0].mDataByteSize);
+        UInt32 bytesToCopy = (UInt32)min(bytesToGo, bufferList->mBuffers[0].mDataByteSize);
         
         if ( outputBufferList ) {
             for ( UInt32 i=0; i<outputBufferList->mNumberBuffers; i++ ) {

--- a/TPCircularBuffer+AudioBufferList.c
+++ b/TPCircularBuffer+AudioBufferList.c
@@ -32,19 +32,19 @@
 
 static double __secondsToHostTicks = 0.0;
 
-static inline long align16byte(long val) {
+static inline unsigned long align16byte(unsigned long val) {
     if ( val & (16-1) ) {
         return val + (16 - (val & (16-1)));
     }
     return val;
 }
 
-static inline long min(long a, long b) {
+static inline unsigned long min(unsigned long a, unsigned long b) {
     return a > b ? b : a;
 }
 
-AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferList(TPCircularBuffer *buffer, int numberOfBuffers, int bytesPerBuffer, const AudioTimeStamp *inTimestamp) {
-    int32_t availableBytes;
+AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferList(TPCircularBuffer *buffer, UInt32 numberOfBuffers, UInt32 bytesPerBuffer, const AudioTimeStamp *inTimestamp) {
+    uint32_t availableBytes;
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferHead(buffer, &availableBytes);
     if ( !block || availableBytes < sizeof(TPCircularBufferABLBlockHeader)+((numberOfBuffers-1)*sizeof(AudioBuffer))+(numberOfBuffers*bytesPerBuffer) ) return NULL;
     
@@ -62,11 +62,11 @@ AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferList(TPCircularBuffer *b
     block->bufferList.mNumberBuffers = numberOfBuffers;
     
     char *dataPtr = (char*)&block->bufferList + sizeof(AudioBufferList)+((numberOfBuffers-1)*sizeof(AudioBuffer));
-    for ( int i=0; i<numberOfBuffers; i++ ) {
+    for ( UInt32 i=0; i<numberOfBuffers; i++ ) {
         // Find the next 16-byte aligned memory area
-        dataPtr = (char*)align16byte((long)dataPtr);
+        dataPtr = (char*)align16byte((unsigned long)dataPtr);
         
-        if ( (dataPtr + bytesPerBuffer) - (char*)block > availableBytes ) {
+        if ( (UInt32)((dataPtr + bytesPerBuffer) - (char*)block) > availableBytes ) {
             return NULL;
         }
         
@@ -78,7 +78,7 @@ AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferList(TPCircularBuffer *b
     }
     
     // Make sure whole buffer (including timestamp and length value) is 16-byte aligned in length
-    block->totalLength = (UInt32)align16byte(dataPtr - (char*)block);
+    block->totalLength = (UInt32)align16byte((unsigned long)(dataPtr - (char*)block));
     if ( block->totalLength > availableBytes ) {
         return NULL;
     }
@@ -94,7 +94,7 @@ AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferListWithAudioFormat(TPCi
 }
 
 void TPCircularBufferProduceAudioBufferList(TPCircularBuffer *buffer, const AudioTimeStamp *inTimestamp) {
-    int32_t availableBytes;
+    uint32_t availableBytes;
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferHead(buffer, &availableBytes);
     
     assert(block);
@@ -124,7 +124,7 @@ void TPCircularBufferProduceAudioBufferList(TPCircularBuffer *buffer, const Audi
 bool TPCircularBufferCopyAudioBufferList(TPCircularBuffer *buffer, const AudioBufferList *inBufferList, const AudioTimeStamp *inTimestamp, UInt32 frames, const AudioStreamBasicDescription *audioDescription) {
     if ( frames == 0 ) return true;
     
-    int byteCount = inBufferList->mBuffers[0].mDataByteSize;
+    UInt32 byteCount = inBufferList->mBuffers[0].mDataByteSize;
     if ( frames != kTPCircularBufferCopyAll ) {
         byteCount = frames * audioDescription->mBytesPerFrame;
         assert(byteCount <= inBufferList->mBuffers[0].mDataByteSize);
@@ -135,7 +135,7 @@ bool TPCircularBufferCopyAudioBufferList(TPCircularBuffer *buffer, const AudioBu
     AudioBufferList *bufferList = TPCircularBufferPrepareEmptyAudioBufferList(buffer, inBufferList->mNumberBuffers, byteCount, inTimestamp);
     if ( !bufferList ) return false;
     
-    for ( int i=0; i<bufferList->mNumberBuffers; i++ ) {
+    for ( UInt32 i=0; i<bufferList->mNumberBuffers; i++ ) {
         memcpy(bufferList->mBuffers[i].mData, inBufferList->mBuffers[i].mData, byteCount);
     }
     
@@ -145,7 +145,7 @@ bool TPCircularBufferCopyAudioBufferList(TPCircularBuffer *buffer, const AudioBu
 }
 
 AudioBufferList *TPCircularBufferNextBufferListAfter(TPCircularBuffer *buffer, const AudioBufferList *bufferList, AudioTimeStamp *outTimestamp) {
-    int32_t availableBytes;
+    uint32_t availableBytes;
     void *tail = TPCircularBufferTail(buffer, &availableBytes);
     void *end = (char*)tail + availableBytes;
     assert((void*)bufferList > (void*)tail && (void*)bufferList < end);
@@ -170,10 +170,9 @@ AudioBufferList *TPCircularBufferNextBufferListAfter(TPCircularBuffer *buffer, c
     return &nextBlock->bufferList;
 }
 
-void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, int framesToConsume, const AudioStreamBasicDescription *audioFormat) {
-    assert(framesToConsume >= 0);
+void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, UInt32 framesToConsume, const AudioStreamBasicDescription *audioFormat) {
     
-    int32_t dontcare;
+    uint32_t dontcare;
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferTail(buffer, &dontcare);
     if ( !block ) return;
     
@@ -181,14 +180,14 @@ void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, int 
     assert(!((unsigned long)block & 0xF)); // Beware unaligned accesses
     #endif
     
-    int bytesToConsume = (int)min(framesToConsume * audioFormat->mBytesPerFrame, block->bufferList.mBuffers[0].mDataByteSize);
+    UInt32 bytesToConsume = (UInt32)min(framesToConsume * audioFormat->mBytesPerFrame, block->bufferList.mBuffers[0].mDataByteSize);
     
     if ( bytesToConsume == block->bufferList.mBuffers[0].mDataByteSize ) {
         TPCircularBufferConsumeNextBufferList(buffer);
         return;
     }
     
-    for ( int i=0; i<block->bufferList.mNumberBuffers; i++ ) {
+    for ( UInt32 i=0; i<block->bufferList.mNumberBuffers; i++ ) {
         assert(bytesToConsume <= block->bufferList.mBuffers[i].mDataByteSize);
         
         block->bufferList.mBuffers[i].mData = (char*)block->bufferList.mBuffers[i].mData + bytesToConsume;
@@ -211,9 +210,9 @@ void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, int 
     // Reposition block forward, just before the audio data, ensuring 16-byte alignment
     TPCircularBufferABLBlockHeader *newBlock = (TPCircularBufferABLBlockHeader*)(((unsigned long)block + bytesToConsume) & ~0xFul);
     memmove(newBlock, block, sizeof(TPCircularBufferABLBlockHeader) + (block->bufferList.mNumberBuffers-1)*sizeof(AudioBuffer));
-    intptr_t bytesFreed = (intptr_t)newBlock - (intptr_t)block;
+    UInt32 bytesFreed = (UInt32)((intptr_t)newBlock - (intptr_t)block);
     newBlock->totalLength -= bytesFreed;
-    TPCircularBufferConsume(buffer, (int32_t)bytesFreed);
+    TPCircularBufferConsume(buffer, bytesFreed);
 }
 
 void TPCircularBufferDequeueBufferListFrames(TPCircularBuffer *buffer, UInt32 *ioLengthInFrames, const AudioBufferList *outputBufferList, AudioTimeStamp *outTimestamp, const AudioStreamBasicDescription *audioFormat) {
@@ -225,16 +224,16 @@ void TPCircularBufferDequeueBufferListFrames(TPCircularBuffer *buffer, UInt32 *i
         if ( !bufferList ) break;
         
         hasTimestamp = true;
-        long bytesToCopy = min(bytesToGo, bufferList->mBuffers[0].mDataByteSize);
+        unsigned long bytesToCopy = min(bytesToGo, bufferList->mBuffers[0].mDataByteSize);
         
         if ( outputBufferList ) {
-            for ( int i=0; i<outputBufferList->mNumberBuffers; i++ ) {
+            for ( UInt32 i=0; i<outputBufferList->mNumberBuffers; i++ ) {
                 assert(bytesCopied + bytesToCopy <= outputBufferList->mBuffers[i].mDataByteSize);
                 memcpy((char*)outputBufferList->mBuffers[i].mData + bytesCopied, bufferList->mBuffers[i].mData, bytesToCopy);
             }
         }
         
-        TPCircularBufferConsumeNextBufferListPartial(buffer, (int)bytesToCopy/audioFormat->mBytesPerFrame, audioFormat);
+        TPCircularBufferConsumeNextBufferListPartial(buffer, bytesToCopy/audioFormat->mBytesPerFrame, audioFormat);
         
         bytesToGo -= bytesToCopy;
         bytesCopied += bytesToCopy;
@@ -244,7 +243,7 @@ void TPCircularBufferDequeueBufferListFrames(TPCircularBuffer *buffer, UInt32 *i
 }
 
 UInt32 TPCircularBufferPeekContiguousWrapped(TPCircularBuffer *buffer, AudioTimeStamp *outTimestamp, const AudioStreamBasicDescription *audioFormat, UInt32 contiguousToleranceSampleTime, UInt32 wrapPoint) {
-    int32_t availableBytes;
+    uint32_t availableBytes;
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferTail(buffer, &availableBytes);
     if ( !block ) return 0;
     
@@ -297,7 +296,7 @@ UInt32 TPCircularBufferPeekContiguous(TPCircularBuffer *buffer, AudioTimeStamp *
 
 UInt32 TPCircularBufferGetAvailableSpace(TPCircularBuffer *buffer, const AudioStreamBasicDescription *audioFormat) {
     // Look at buffer head; make sure there's space for the block metadata
-    int32_t availableBytes;
+    uint32_t availableBytes;
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferHead(buffer, &availableBytes);
     if ( !block ) return 0;
     
@@ -306,13 +305,13 @@ UInt32 TPCircularBufferGetAvailableSpace(TPCircularBuffer *buffer, const AudioSt
     #endif
     
     // Now find out how much 16-byte aligned audio we can store in the space available
-    int numberOfBuffers = audioFormat->mFormatFlags & kAudioFormatFlagIsNonInterleaved ? audioFormat->mChannelsPerFrame : 1;
+    UInt32 numberOfBuffers = audioFormat->mFormatFlags & kAudioFormatFlagIsNonInterleaved ? audioFormat->mChannelsPerFrame : 1;
     char * endOfBuffer = (char*)block + availableBytes;
-    char * dataPtr = (char*)align16byte((long)(&block->bufferList + sizeof(AudioBufferList)+((numberOfBuffers-1)*sizeof(AudioBuffer))));
+    char * dataPtr = (char*)align16byte((unsigned long)(&block->bufferList + sizeof(AudioBufferList)+((numberOfBuffers-1)*sizeof(AudioBuffer))));
     if ( dataPtr >= endOfBuffer ) return 0;
-    int32_t availableAudioBytes = (int)(endOfBuffer - dataPtr);
+    UInt32 availableAudioBytes = (UInt32)(endOfBuffer - dataPtr);
     
-    int32_t availableAudioBytesPerBuffer = availableAudioBytes / numberOfBuffers;
+    UInt32 availableAudioBytesPerBuffer = availableAudioBytes / numberOfBuffers;
     availableAudioBytesPerBuffer -= (availableAudioBytesPerBuffer % (16-1));
     
     return availableAudioBytesPerBuffer > 0 ? availableAudioBytesPerBuffer / audioFormat->mBytesPerFrame : 0;

--- a/TPCircularBuffer+AudioBufferList.c
+++ b/TPCircularBuffer+AudioBufferList.c
@@ -198,7 +198,7 @@ void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, UInt
         block->timestamp.mSampleTime += framesToConsume;
     }
     if ( block->timestamp.mFlags & kAudioTimeStampHostTimeValid ) {
-        if ( !__secondsToHostTicks ) {
+        if ( __secondsToHostTicks == 0.0 ) {
             mach_timebase_info_data_t tinfo;
             mach_timebase_info(&tinfo);
             __secondsToHostTicks = 1.0 / (((double)tinfo.numer / tinfo.denom) * 1.0e-9);

--- a/TPCircularBuffer+AudioBufferList.h
+++ b/TPCircularBuffer+AudioBufferList.h
@@ -55,7 +55,7 @@ typedef struct {
  * @param timestamp         The timestamp associated with the buffer, or NULL. Note that you can also pass a timestamp into TPCircularBufferProduceAudioBufferList, to set it there instead.
  * @return The empty buffer list, or NULL if circular buffer has insufficient space
  */
-AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferList(TPCircularBuffer *buffer, int numberOfBuffers, int bytesPerBuffer, const AudioTimeStamp *timestamp);
+AudioBufferList *TPCircularBufferPrepareEmptyAudioBufferList(TPCircularBuffer *buffer, UInt32 numberOfBuffers, UInt32 bytesPerBuffer, const AudioTimeStamp *timestamp);
 
 /*!
  * Prepare an empty buffer list, stored on the circular buffer, using an audio description to automatically configure buffer
@@ -100,7 +100,7 @@ bool TPCircularBufferCopyAudioBufferList(TPCircularBuffer *buffer, const AudioBu
  * @return Pointer to the next buffer list in the buffer
  */
 static __inline__ __attribute__((always_inline)) AudioBufferList *TPCircularBufferNextBufferList(TPCircularBuffer *buffer, AudioTimeStamp *outTimestamp) {
-    int32_t dontcare; // Length of segment is contained within buffer list, so we can ignore this
+    uint32_t dontcare; // Length of segment is contained within buffer list, so we can ignore this
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferTail(buffer, &dontcare);
     if ( !block ) {
         if ( outTimestamp ) {
@@ -130,7 +130,7 @@ AudioBufferList *TPCircularBufferNextBufferListAfter(TPCircularBuffer *buffer, c
  * @param buffer Circular buffer
  */
 static __inline__ __attribute__((always_inline)) void TPCircularBufferConsumeNextBufferList(TPCircularBuffer *buffer) {
-    int32_t dontcare;
+    uint32_t dontcare;
     TPCircularBufferABLBlockHeader *block = (TPCircularBufferABLBlockHeader*)TPCircularBufferTail(buffer, &dontcare);
     if ( !block ) return;
     TPCircularBufferConsume(buffer, block->totalLength);
@@ -146,7 +146,7 @@ static __inline__ __attribute__((always_inline)) void TPCircularBufferConsumeNex
  * @param framesToConsume The number of frames to consume from the buffer list
  * @param audioFormat The AudioStreamBasicDescription describing the audio
  */
-void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, int framesToConsume, const AudioStreamBasicDescription *audioFormat);
+void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, UInt32 framesToConsume, const AudioStreamBasicDescription *audioFormat);
 
 /*!
  * Consume a certain number of frames from the buffer, possibly from multiple queued buffer lists

--- a/TPCircularBuffer.c
+++ b/TPCircularBuffer.c
@@ -54,7 +54,7 @@ bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t str
     int retries = 3;
     while ( true ) {
 
-        buffer->length = round_page(length);    // We need whole page sizes
+        buffer->length = (uint32_t)round_page(length);    // We need whole page sizes
 
         // Temporarily allocate twice the length, so we have the contiguous address space to
         // support a second instance of the buffer directly after

--- a/TPCircularBuffer.c
+++ b/TPCircularBuffer.c
@@ -41,7 +41,7 @@ static inline bool _reportResult(kern_return_t result, const char *operation, co
     return true;
 }
 
-bool _TPCircularBufferInit(TPCircularBuffer *buffer, int32_t length, size_t structSize) {
+bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t structSize) {
     
     assert(length > 0);
     
@@ -54,7 +54,7 @@ bool _TPCircularBufferInit(TPCircularBuffer *buffer, int32_t length, size_t stru
     int retries = 3;
     while ( true ) {
 
-        buffer->length = (int32_t)round_page(length);    // We need whole page sizes
+        buffer->length = round_page(length);    // We need whole page sizes
 
         // Temporarily allocate twice the length, so we have the contiguous address space to
         // support a second instance of the buffer directly after
@@ -138,7 +138,7 @@ void TPCircularBufferCleanup(TPCircularBuffer *buffer) {
 }
 
 void TPCircularBufferClear(TPCircularBuffer *buffer) {
-    int32_t fillCount;
+    uint32_t fillCount;
     if ( TPCircularBufferTail(buffer, &fillCount) ) {
         TPCircularBufferConsume(buffer, fillCount);
     }


### PR DESCRIPTION
This PR makes the TPCurcularBuffer API compatible with Core Audio by using ``UInt32`` instead of ``int`` for all fields that are interfacing with Core Audio. It also uses ``uint32_t`` instead of ``int`` for fields that are supposed to be positive only. As a side effect this change silences aggressive C compiler warnings about comparison, conversion, and assignment of signed/unsigned int values.

Tested on iOS/macOS project(s) under XCode 9.2.