### PR TITLE
fix: silence compiler warning

### DIFF
--- a/TPCircularBuffer+AudioBufferList.c
+++ b/TPCircularBuffer+AudioBufferList.c
@@ -204,7 +204,7 @@ void TPCircularBufferConsumeNextBufferListPartial(TPCircularBuffer *buffer, UInt
             __secondsToHostTicks = 1.0 / (((double)tinfo.numer / tinfo.denom) * 1.0e-9);
         }
 
-        block->timestamp.mHostTime += ((double)framesToConsume / audioFormat->mSampleRate) * __secondsToHostTicks;
+        block->timestamp.mHostTime += (UInt64)((double)framesToConsume / audioFormat->mSampleRate) * __secondsToHostTicks;
     }
     
     // Reposition block forward, just before the audio data, ensuring 16-byte alignment


### PR DESCRIPTION
This is just a housekeeping PR to make build clean on Xcode 12.5 before WWDC :) Thanks!