### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "TPCircularBuffer",
+    products: [
+        .library(name: "TPCircularBuffer", targets: ["CTPCircularBuffer"]),
+    ],
+    targets: [
+        .target(name: "CTPCircularBuffer", path: "", publicHeadersPath: ""),
+    ]
+)


### PR DESCRIPTION
I can see there are already two open merge requests adding this, but I think this is the least invasive way. It is purely additive (no files moved). I tested and no code changes are required on the client side when switching to the package.

I named the target `CTPCircularBuffer` based on a naming convention used in Server-Side Swift packages, but a name different from `TPCircularBuffer` is required anyway, because `TPCircularBuffer.h` is not an umbrella header.

The library is named `TPCircularBuffer`, and `#includes` can use header names like before, so the only places a client of the package would see the `CTPCircularBuffer` name is if using module imports (e.g. `@import CTPCircularBuffer;`) and in Swift.