### PR TITLE
Accessing the buffer's fillCount from Swift

### DIFF
--- a/TPCircularBuffer.c
+++ b/TPCircularBuffer.c
@@ -147,3 +147,7 @@ void TPCircularBufferClear(TPCircularBuffer *buffer) {
 void  TPCircularBufferSetAtomic(TPCircularBuffer *buffer, bool atomic) {
     buffer->atomic = atomic;
 }
+
+int TPCircularBufferFillCount(TPCircularBuffer *buffer) {
+	return buffer->fillCount;
+}

--- a/TPCircularBuffer.h
+++ b/TPCircularBuffer.h
@@ -125,6 +125,17 @@ void  TPCircularBufferClear(TPCircularBuffer *buffer);
  */
 void  TPCircularBufferSetAtomic(TPCircularBuffer *buffer, bool atomic);
 
+/*!
+ * Access fillCount from Swift
+ *
+ *  Swift cannot access C atomic integers, so this function
+ *  will return the fillCount of the buffer, and can be called in Swift
+ *  provided that this header is imported in your Bridging Header
+ *
+ * @param buffer Circular buffer
+ */
+int  TPCircularBufferFillCount(TPCircularBuffer *buffer);
+
 // Reading (consuming)
 
 /*!


### PR DESCRIPTION
Added TPCircularBufferFillCount function for accessing the buffer's fillCount from Swift